### PR TITLE
feat: origin

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -5,7 +5,8 @@ import os
 
 DEFAUT_CONFIG = {
     "prefered-shell":"/bin/bash",
-    "prefered-editor": "vim"
+    "prefered-editor": "vim",
+    "prefered-web_browser": "google-chrome"
 }
 
 OMG_DATA_PATH = os.path.join(os.path.expanduser("~"), ".omg")

--- a/src/core/repositories.py
+++ b/src/core/repositories.py
@@ -94,7 +94,7 @@ def get_repository_from_proxy(repository_proxy: str) -> dict:
     else:
         return next(
             (repository for repository in REPOSITORIES.values() \
-            if repository["path"] in repository_path),
+            if f"{repository_path}{os.sep}".startswith(f'{repository["path"]}{os.sep}')),
             None)
 
 # retrive all repostories' data

--- a/src/core/repositories.py
+++ b/src/core/repositories.py
@@ -31,14 +31,14 @@ except:  # avoid crashing when the json is empty or wrong
 
 
 def check_repository(repository_proxy: str) -> bool:
+    repository_path = os.path.abspath(repository_proxy)
+
     # check if repository_proxy is known, if yes retrieve path
     if repository_proxy in REPOSITORIES.keys():
         repository_path = REPOSITORIES[repository_proxy]["path"]
-    elif repository_proxy in [
+    elif repository_path not in [
         repository_data["path"] for repository_data in REPOSITORIES.values()
     ]:
-        repository_path = repository_proxy
-    else:
         return ""
 
     # return repository path if it still exists
@@ -84,6 +84,18 @@ def update_repository(repository_name: str, repository_data_to_update: dict) -> 
 def get_repository(repository_name: str) -> dict:
     return REPOSITORIES[repository_name]
 
+# retrive a repository's data from its name/path
+def get_repository_from_proxy(repository_proxy: str) -> dict:
+    repository_path = os.path.abspath(repository_proxy)
+
+    # check if repository_proxy is known, if yes retrieve path
+    if repository_proxy in REPOSITORIES.keys():
+        return REPOSITORIES[repository_proxy]  
+    else:
+        return next(
+            (repository for repository in REPOSITORIES.values() \
+            if repository["path"] in repository_path),
+            None)
 
 # retrive all repostories' data
 def get_repositories() -> dict:

--- a/src/modules/core-modules/origin.py
+++ b/src/modules/core-modules/origin.py
@@ -1,0 +1,35 @@
+from core.tui.components import REPOSITORY_DOES_NOT_EXIST_MESSAGE
+from core.exceptions import RepositoryDoesNotExistsException
+import core.repositories
+from typing import List
+import core.config
+import argparse
+import sys
+import os
+
+def entrypoint(argv : List[str])->None:
+    # init parser
+    parser = argparse.ArgumentParser(
+                        prog='omg origin',
+                        description="omg rm allows you to show/open the origin of a specific git repository.",
+                        epilog="See 'omg --help' to get further help")
+
+    # add arguments
+    parser.add_argument("repository_alias",help="select the repository by its alias", nargs="?", type=str,default=".")
+    parser.add_argument("-s","--show",help="only show the origin in the terminal, without opening it",action="store_true")
+
+    # parse argv
+    args = parser.parse_args(argv)
+
+    # fetch config
+    prefered_web_browser = core.config.get_config("prefered-web_browser")
+    
+    repository = core.repositories.get_repository_from_proxy(args.repository_alias)
+    if repository:
+        origin = repository["origin"]
+        if args.show:
+            print(origin)
+        else:
+            os.system(f"{prefered_web_browser} '{origin}'")
+    else:
+        raise RepositoryDoesNotExistsException(REPOSITORY_DOES_NOT_EXIST_MESSAGE(args.repository_alias))


### PR DESCRIPTION
Show in the terminal or open in the favourite browser the origin of a repository

usage:
```bash
omg origin <path_to_repo | repo_alias> [--show]
omg origin [--show] # will target the repository of the current working directory
```

the `--show` option is used if you only want to check what the origin is and not open it.

a new get repository method to get the repository from either its alias or path has been added in the core.repository file
